### PR TITLE
Add GenerateId xUnit tests

### DIFF
--- a/tests/DndDashboard.Api.Tests/DndDashboard.Api.Tests.csproj
+++ b/tests/DndDashboard.Api.Tests/DndDashboard.Api.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\apps\DndDashboard.Api\DndDashboard.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DndDashboard.Api.Tests/GenerateIdTests.cs
+++ b/tests/DndDashboard.Api.Tests/GenerateIdTests.cs
@@ -1,0 +1,17 @@
+using DndDashboard.Api.Helper;
+
+namespace DndDashboard.Api.Tests;
+
+public class GenerateIdTests
+{
+    [Fact]
+    public void GenerateIdCreates16CharString()
+    {
+        var first = GenerateId.Create();
+        var second = GenerateId.Create();
+
+        Assert.Equal(16, first.Length);
+        Assert.Equal(16, second.Length);
+        Assert.NotEqual(first, second);
+    }
+}


### PR DESCRIPTION
## Summary
- add `DndDashboard.Api.Tests` xUnit project
- test `GenerateId.Create()` returns unique 16 character strings

## Testing
- `dotnet test tests/DndDashboard.Api.Tests/DndDashboard.Api.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684707939e90832d9f765ea13248a1ce